### PR TITLE
Set default for vars unrequired when create_lc is false

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: git://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.7.0
+  rev: v1.7.3
   hooks:
     - id: terraform_fmt
     - id: terraform_docs

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ There are two ways to specify tags for auto-scaling group in this module - `tags
 | asg_name | Creates a unique name for autoscaling group beginning with the specified prefix | string | `` | no |
 | associate_public_ip_address | Associate a public ip address with an instance in a VPC | string | `false` | no |
 | create_asg | Whether to create autoscaling group | string | `true` | no |
+| create_asg_with_initial_lifecycle_hook | Create an ASG with intial | string | `false` | no |
 | create_lc | Whether to create launch configuration | string | `true` | no |
 | default_cooldown | The amount of time, in seconds, after a scaling activity completes before another scaling activity can start | string | `300` | no |
 | desired_capacity | The number of Amazon EC2 instances that should be running in the group | string | - | yes |
@@ -127,15 +128,15 @@ There are two ways to specify tags for auto-scaling group in this module - `tags
 | health_check_grace_period | Time (in seconds) after instance comes into service before checking health | string | `300` | no |
 | health_check_type | Controls how health checking is done. Values are - EC2 and ELB | string | - | yes |
 | iam_instance_profile | The IAM instance profile to associate with launched instances | string | `` | no |
-| image_id | The EC2 image ID to launch | string | - | yes |
-| initial_lifecycle_hook_name | Name of the inital lifecycle hook | string | - | yes
-| initial_lifecycle_hook_transition | Lifecycle hook transition type | string | - | yes
-| initial_lifecycle_hook_notification_metadata | Metadata sent from the lifecycle hook | string | - | no
-| initial_lifecycle_hook_heartbeat_time | Time in seconds before the lifecycle hook times out | string | `60` | no
-| initial_lifecycle_hook_notification_target_arn | Arn of the notification target can be SQS queue or SNS topic | string | - | no 
-| initial_lifecycle_hook_role_arn | The ARN of the IAM role that allows ASG to publish to specified target ARN | string | - | no
-| initial_lifecycle_hook_default_result | Defines the Action the ASG should take when the lifecycle hook times out or fails | string | `continue` | no
-| instance_type | The size of instance to launch | string | - | yes |
+| image_id | The EC2 image ID to launch | string | `` | no |
+| initial_lifecycle_hook_default_result | Defines the default action the autoscaler takes when the lifecyle hook timesout | string | `CONTINUE` | no |
+| initial_lifecycle_hook_heartbeat_time | Lifecyle action timer | string | `60` | no |
+| initial_lifecycle_hook_name | Initial lifecycle hook name required parameter | string | `` | no |
+| initial_lifecycle_hook_notification_metadata | Metadata for the lifecycle notification event | string | `` | no |
+| initial_lifecycle_hook_notification_target_arn | SNS target arn to allow notifications from autoscaling group | string | `` | no |
+| initial_lifecycle_hook_role_arn | AWS iam role to grant access to notification target | string | `` | no |
+| initial_lifecycle_hook_transition | Initial Lifecycle hook transtion type | string | `` | no |
+| instance_type | The size of instance to launch | string | `` | no |
 | key_name | The key name that should be used for the instance | string | `` | no |
 | launch_configuration | The name of the launch configuration to use (if it is created outside of this module) | string | `` | no |
 | lc_name | Creates a unique name for launch configuration beginning with the specified prefix | string | `` | no |
@@ -150,7 +151,7 @@ There are two ways to specify tags for auto-scaling group in this module - `tags
 | protect_from_scale_in | Allows setting instance protection. The autoscaling group will not select instances with this setting for terminination during scale in events. | string | `false` | no |
 | recreate_asg_when_lc_changes | Whether to recreate an autoscaling group when launch configuration changes | string | `false` | no |
 | root_block_device | Customize details about the root block device of the instance | list | `<list>` | no |
-| security_groups | A list of security group IDs to assign to the launch configuration | list | - | yes |
+| security_groups | A list of security group IDs to assign to the launch configuration | list | `<list>` | no |
 | spot_price | The price to use for reserving spot instances | string | `` | no |
 | suspended_processes | A list of processes to suspend for the AutoScaling Group. The allowed values are Launch, Terminate, HealthCheck, ReplaceUnhealthy, AZRebalance, AlarmNotification, ScheduledActions, AddToLoadBalancer. Note that if you suspend either the Launch or Terminate process types, it can prevent your autoscaling group from functioning properly. | string | `<list>` | no |
 | tags | A list of tag blocks. Each element should have keys named key, value, and propagate_at_launch. | string | `<list>` | no |

--- a/examples/asg_inital_lifecycle_hook/main.tf
+++ b/examples/asg_inital_lifecycle_hook/main.tf
@@ -53,13 +53,14 @@ module "example" {
 
   name = "example-with-ec2-lifecycle-hook"
 
-  create_asg = false
+  create_asg                             = false
   create_asg_with_initial_lifecycle_hook = true
 
-  initial_lifecycle_hook_name                  = "ExampleLifeCycleHook"
-  initial_lifecycle_hook_transition            = "autoscaling:EC2_INSTANCE_TERMINATING"
+  initial_lifecycle_hook_name       = "ExampleLifeCycleHook"
+  initial_lifecycle_hook_transition = "autoscaling:EC2_INSTANCE_TERMINATING"
+
   # This could be a rendered data resource
-  initial_lifecycle_hook_notification_metadata =<<EOF
+  initial_lifecycle_hook_notification_metadata = <<EOF
 {
   "foo": "bar"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -75,10 +75,12 @@ variable "launch_configuration" {
 # Launch configuration
 variable "image_id" {
   description = "The EC2 image ID to launch"
+  default     = ""
 }
 
 variable "instance_type" {
   description = "The size of instance to launch"
+  default     = ""
 }
 
 variable "iam_instance_profile" {
@@ -94,6 +96,7 @@ variable "key_name" {
 variable "security_groups" {
   description = "A list of security group IDs to assign to the launch configuration"
   type        = "list"
+  default     = []
 }
 
 variable "associate_public_ip_address" {


### PR DESCRIPTION
Updated README.md

Changed launch_configuration to colescelist from element() to avoid create_lc = false empty list

Added depends on to avoid splat dependancies issues